### PR TITLE
add gunicorn to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.3
 Werkzeug==2.3.7
+gunicorn==21.2.0


### PR DESCRIPTION
This patch adds Gunicorn to requirements.txt, allowing us to use it over Werkezeug.